### PR TITLE
test(router): unify router tests for 'search-cmp' and 'app' & refactor debugElement usage

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { CounterComponent } from './basic/counter/counter.component';
 import { CounterRouterComponent } from './basic/counter-router/counter-router.component';
 import { FatherComponent } from './basic/father/father.component';
 import { FatherSonComponent } from './basic/father-son/father-son.component';
+import { SearchComponent } from './basic/search/search.component';
 
 export const routes: Routes = [
   {
@@ -31,6 +32,10 @@ export const routes: Routes = [
     path: '',
     redirectTo: '/basic/counter',
     pathMatch: 'full',
+  },
+  {
+    path: 'basic/search',
+    component: SearchComponent,
   },
   {
     path: '**',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -28,6 +28,11 @@ export const routes: Routes = [
     component: FatherSonComponent,
   },
   {
+    path: '',
+    redirectTo: '/basic/counter',
+    pathMatch: 'full',
+  },
+  {
     path: '**',
     component: CounterComponent,
   },

--- a/src/app/basic/search/search.component.ts
+++ b/src/app/basic/search/search.component.ts
@@ -1,0 +1,19 @@
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'app-search',
+  standalone: true,
+  imports: [AsyncPipe],
+  template: `search: {{ (_route.queryParams | async)?.['search'] }}`,
+  styleUrl: './search.component.scss',
+})
+export class SearchComponent {
+  public _route = inject(ActivatedRoute);
+  public _router = inject(Router);
+
+  public searchFor(searchText: string): Promise<boolean> {
+    return this._router.navigate([], { queryParams: { search: searchText } });
+  }
+}

--- a/src/app/basic/tests/counter-router.component.spec.ts
+++ b/src/app/basic/tests/counter-router.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { routes } from '../../app.routes';
@@ -68,25 +73,79 @@ describe('CounterRouterComponent', () => {
     expect(component.counter()).toBe(10);
   });
 
-  it('should redirect to default route when initial value is 0', async () => {
+  describe('CounterRouterComponent (fakeAsync + tick)', () => {
     const mockActivatedRoute = createMockActivatedRoute('0');
 
-    await TestBed.configureTestingModule({
-      declarations: [CounterRouterComponent],
-      imports: [RouterModule.forRoot(routes)],
-      providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
-    }).compileComponents();
+    // It allows Angular to run everything in a simulated zone
+    // where asynchronous time is controlled
+    it('fakeAsync/tick() - should redirect to default route when initial value is 0', fakeAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [CounterRouterComponent],
+        imports: [RouterModule.forRoot(routes)],
+        providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
+      }).compileComponents();
 
-    fixture = TestBed.createComponent(CounterRouterComponent);
-    component = fixture.componentInstance;
-    router = TestBed.inject(Router);
-    fixture.detectChanges();
+      fixture = TestBed.createComponent(CounterRouterComponent);
+      component = fixture.componentInstance;
+      router = TestBed.inject(Router);
 
-    // Run the test within Angular's NgZone to handle asynchronous operations, including router.navigate
-    fixture.ngZone?.run(() => {
+      fixture.detectChanges();
+
       const routerSpy = jest.spyOn(router, 'navigate');
+
+      // logic that triggers navigation
       component.ngOnInit();
+
+      // simulates the passage of time and forces asynchronous tasks to complete.
+      // ---
+      // it ‘advances’ time within the fakeAsync zone,
+      // so that if there are pending tasks (such as those triggered internally by the router), // they are completed before the test ends,
+      // are completed before the end of the test.
+      tick();
+
+      expect(routerSpy).toHaveBeenCalledWith(['/']);
+    }));
+
+    // delegates to Angular the handling of pending tasks in a more automatic way.
+    it('async/whenStable() - should redirect to default route when initial value is 0', async () => {
+      await TestBed.configureTestingModule({
+        declarations: [CounterRouterComponent],
+        imports: [RouterModule.forRoot(routes)],
+        providers: [{ provide: ActivatedRoute, useValue: mockActivatedRoute }],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(CounterRouterComponent);
+      component = fixture.componentInstance;
+      router = TestBed.inject(Router);
+      fixture.detectChanges();
+
+      const routerSpy = jest.spyOn(router, 'navigate');
+
+      // logic that triggers navigation
+      component.ngOnInit();
+
+      // waits for all asynchronous Angular tasks to complete
+      // ---
+      // Returns a promise that is resolved when Angular completes all asynchronous processes
+      // asynchronous processes in the sandbox (including router navigation,
+      // change detection, etc.).
+      await fixture.whenStable();
+
       expect(routerSpy).toHaveBeenCalledWith(['/']);
     });
+
+    // ---------------
+
+    // by wrapping the code block inside fixture.ngZone.run(...), we force everything
+    //  that happens in that callback to run in the Angular zone,
+    // and hence the change detection and navigation sequence to behave as in a real app.
+
+    // fixture.ngZone?.run(() => {
+    // const routerSpy = jest.spyOn(router, 'navigate');
+    // component.ngOnInit();
+    // expect(routerSpy).toHaveBeenCalledWith(['/']);
+    // });
+
+    // ---------------
   });
 });

--- a/src/app/basic/tests/search.component.spec.ts
+++ b/src/app/basic/tests/search.component.spec.ts
@@ -1,0 +1,96 @@
+/* eslint-disable unused-imports/no-unused-imports */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { BehaviorSubject } from 'rxjs';
+
+import { routes } from '../../app.routes';
+import { SearchComponent } from '../search/search.component';
+
+describe('SearchComponent (con Jest)', () => {
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
+
+  // simulate the ActivatedRoute with a BehaviorSubject
+  // const activatedRouteStub = { queryParams: new BehaviorSubject<any>({}) };
+
+  // in Jest, instead of jasmine.createSpyObj, we use an object with mock functions.
+  // const routerStub = {
+  //   navigate: jest
+  //     .fn()
+  //     .mockImplementation(
+  //       (commands: any, navigationExtras: { queryParams: any }) => {
+  //         activatedRouteStub.queryParams.next(navigationExtras.queryParams);
+  //       }
+  //     ),
+  // };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchComponent],
+      providers: [
+        provideRouter(routes),
+        // { provide: Router, useValue: routerStub },
+        // { provide: ActivatedRoute, useValue: activatedRouteStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('it should be created properly', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('should display the text "search: books', () => {
+    // This block (commented out) shows the classic approach for testing without RouterTestingHarness:
+    // it('using the component instance directly ("NORMAL WAY")', async () => {
+    //   await fixture.componentInstance.searchFor('books');
+    //   fixture.detectChanges();
+    //   expect(fixture.nativeElement.innerHTML).toContain('search: books');
+    // });
+
+    describe('Using RouterTestingHarness', () => {
+      it('should display "search: books" when set via query params (ngOnInit)', async () => {
+        // 1) Create the RouterTestingHarness, which handles the internal navigation for Angular
+        const harness = await RouterTestingHarness.create();
+
+        // 2) Navigate to /basic/search?search=books, so ngOnInit can capture that query param
+        await harness.navigateByUrl(
+          '/basic/search?search=books',
+          SearchComponent
+        );
+
+        // 3) Trigger change detection so the template is updated
+        harness.detectChanges();
+
+        // 4) Verify that "search: books" is displayed in the rendered DOM
+        expect(harness.routeNativeElement?.innerHTML).toContain(
+          'search: books'
+        );
+      });
+
+      it('should display "search: books" when calling the searchFor() method explicitly', async () => {
+        const harness = await RouterTestingHarness.create();
+        const activatedComponent = await harness.navigateByUrl(
+          '/basic/search?search=books',
+          SearchComponent
+        );
+
+        // Call searchFor() on the component instance to manually update the query params
+        await activatedComponent.searchFor('books');
+
+        harness.detectChanges();
+
+        // Check that "search: books" is present in the rendered DOM
+        expect(harness.routeNativeElement?.innerHTML).toContain(
+          'search: books'
+        );
+      });
+    });
+  });
+});

--- a/src/app/tests/app.component.spec.ts
+++ b/src/app/tests/app.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { AppComponent } from '../src/app/app.component';
+import { AppComponent } from '../app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {

--- a/src/app/tests/router.spec.ts
+++ b/src/app/tests/router.spec.ts
@@ -1,0 +1,87 @@
+import { Location } from '@angular/common';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
+
+import { AppComponent } from '../app.component';
+import { routes } from '../app.routes';
+import { PokemonService } from '../shared/services/pokemon.service';
+
+describe('Router: App', () => {
+  let router: Router;
+  let location: Location;
+  let fixture: ComponentFixture<AppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        PokemonService,
+        provideRouter(routes),
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    location = TestBed.inject(Location);
+    fixture = TestBed.createComponent(AppComponent);
+
+    router.initialNavigation();
+    fixture.detectChanges();
+  });
+
+  it('navigate to "" should redirect you to /basic/counter', fakeAsync(() => {
+    router.navigate(['']);
+    tick();
+    expect(location.path()).toBe('/basic/counter');
+  }));
+
+  it('navigate to "/basic/counter" should go to /basic/counter', fakeAsync(() => {
+    router.navigate(['/basic/counter']);
+    tick();
+    expect(location.path()).toBe('/basic/counter');
+  }));
+
+  it('navigate to "/basic/counter/10" should go to /basic/counter/10', fakeAsync(() => {
+    router.navigate(['/basic/counter', 10]);
+    tick();
+    expect(location.path()).toBe('/basic/counter/10');
+  }));
+
+  it('navigate to "/basic/charizard" should go to /basic/charizard', fakeAsync(() => {
+    router.navigate(['/basic/charizard']);
+    tick();
+    expect(location.path()).toBe('/basic/charizard');
+  }));
+
+  it('navigate to "/basic/father" should go to /basic/father', fakeAsync(() => {
+    router.navigate(['/basic/father']);
+    tick();
+    expect(location.path()).toBe('/basic/father');
+  }));
+
+  it('navigate to "/basic/son" should go to /basic/son', fakeAsync(() => {
+    router.navigate(['/basic/son']);
+    tick();
+    expect(location.path()).toBe('/basic/son');
+  }));
+
+  it('navigate to a non-existent path should match the wildcard and load the Counter component', fakeAsync(() => {
+    router.navigate(['/this-route-does-not-exist']);
+    tick();
+
+    expect(location.path()).toBe('/this-route-does-not-exist');
+
+    // verify that the `CounterComponent` component was loaded by looking for the component selector
+    const counterWrapper = fixture.nativeElement.querySelector('app-counter');
+    expect(counterWrapper).toBeTruthy();
+  }));
+});

--- a/src/app/tests/router.spec.ts
+++ b/src/app/tests/router.spec.ts
@@ -7,11 +7,13 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { provideRouter } from '@angular/router';
 
 import { AppComponent } from '../app.component';
 import { routes } from '../app.routes';
+import { CounterComponent } from '../basic/counter/counter.component';
 import { PokemonService } from '../shared/services/pokemon.service';
 
 describe('Router: App', () => {
@@ -81,7 +83,9 @@ describe('Router: App', () => {
     expect(location.path()).toBe('/this-route-does-not-exist');
 
     // verify that the `CounterComponent` component was loaded by looking for the component selector
-    const counterWrapper = fixture.nativeElement.querySelector('app-counter');
+    const counterWrapper = fixture.debugElement.query(
+      By.directive(CounterComponent)
+    );
     expect(counterWrapper).toBeTruthy();
   }));
 });


### PR DESCRIPTION
- test(search-cmp): router behaviour with classic approach and RouterTestingHarness method

- refactor(router test): use debugElement.query() instead of nativeElement.querySelector()

- test(app): app's routes, general and default router